### PR TITLE
Rudimentary fix for https://github.com/foenichs/unique-loot/issues/2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "com.foenichs"
-version = "1.0.7"
+version = "1.0.7.1"
 
 repositories {
     mavenCentral()

--- a/src/main/kotlin/com/foenichs/uniqueloot/ChestListener.kt
+++ b/src/main/kotlin/com/foenichs/uniqueloot/ChestListener.kt
@@ -196,7 +196,7 @@ class ChestListener(private val plugin: UniqueLoot) : Listener {
                             NamedTextColor.RED))
 
                         player.playSound(block.location, Sound.BLOCK_CHEST_LOCKED, 1.0f, 1.0f)
-                        Particle.ANGRY_VILLAGER.builder().location(block.location).count(14).receivers(32, true).spawn()
+                        Particle.ANGRY_VILLAGER.builder().location(block.location.add(0.5,0.5,0.5)).count(14).receivers(32, true).spawn()
 
                         plugin.logger.warning("Failed to fill loot: ${ex.message}")
 

--- a/src/main/kotlin/com/foenichs/uniqueloot/ChestListener.kt
+++ b/src/main/kotlin/com/foenichs/uniqueloot/ChestListener.kt
@@ -2,8 +2,6 @@
 
 package com.foenichs.uniqueloot
 
-import com.destroystokyo.paper.ParticleBuilder
-import net.kyori.adventure.key.Key
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.format.NamedTextColor
 import org.bukkit.*
@@ -70,8 +68,7 @@ class ChestListener(private val plugin: UniqueLoot) : Listener {
     // Canonical IDs
 
     private fun canonicalId(block: Block): String {
-        val state = block.state
-        return when (state) {
+        return when (val state = block.state) {
             is Chest -> canonicalChestId(state)
             is Barrel -> "${block.world.uid}:${block.x},${block.y},${block.z}"
             else -> "${block.world.uid}:${block.x},${block.y},${block.z}"


### PR DESCRIPTION
This is a rudimentary fix for the issue described here https://github.com/foenichs/unique-loot/issues/2.

Instead of nothing happening for the player, this fix adds a bit of feedback letting the player know that the plugin couldn't generate the loot.

<img width="1054" height="888" alt="afbeelding" src="https://github.com/user-attachments/assets/ddfe9839-e22a-4a6b-b5d6-2a8e22413ccf" />
